### PR TITLE
telescope: lsp_referencesのレイアウトを調整

### DIFF
--- a/nvim/lua/yyossy/plugins/telescope.lua
+++ b/nvim/lua/yyossy/plugins/telescope.lua
@@ -37,6 +37,13 @@ return {
             return { "--hidden" }
           end,
         },
+        lsp_references = {
+          layout_config = {
+            width = 0.9,
+            height = 0.8,
+            preview_width = 0.45,
+          },
+        },
       },
     })
 


### PR DESCRIPTION
プレビュー幅を45%に設定し、検索結果欄をより広く表示

🤖 Generated with [Claude Code](https://claude.ai/code)


close https://github.com/yyossy5/dotfiles/issues/305