### PR TITLE
feat(nvim): improve window pane separators visibility

### DIFF
--- a/nvim/lua/yyossy/core/options.lua
+++ b/nvim/lua/yyossy/core/options.lua
@@ -44,6 +44,17 @@ opt.clipboard:append("unnamedplus") -- use system clipboard as default register
 opt.splitright = true -- split vertical window to the right
 opt.splitbelow = true -- split horizontal window to the bottom
 
+-- window separators
+opt.fillchars = {
+  vert = "▎", -- thick left block for vertical separator
+  horiz = "━", -- horizontal line for horizontal separator
+  horizup = "┻",
+  horizdown = "┳",
+  vertleft = "┫",
+  vertright = "┣",
+  verthoriz = "╋",
+}
+
 -- turn off swapfile
 opt.swapfile = false
 
@@ -62,4 +73,3 @@ vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter" }, {
 --     vim.opt_local.expandtab = false -- use actual tabs instead of spaces in Java files
 --   end,
 -- })
-

--- a/nvim/lua/yyossy/plugins/colorschema.lua
+++ b/nvim/lua/yyossy/plugins/colorschema.lua
@@ -120,7 +120,11 @@ return {
         },
         palettes = {},
         specs = {},
-        groups = {},
+        groups = {
+          all = {
+            WinSeparator = { fg = "#EBEFFD" },
+          },
+        },
       })
 
       -- setup must be called before loading


### PR DESCRIPTION
- Add custom fillchars with thick blocks and box drawing characters
- Set window separator color to light blue (#EBEFFD) for better visibility
- Enhance split window visual distinction

close https://github.com/yyossy5/dotfiles/issues/342